### PR TITLE
ホットキー設定フォームで何も設定していなかった場合にエラーになる不具合を修正

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -183,6 +183,14 @@ namespace ToggleMuter
 
             //フォームが閉じられた後にホットキーの設定を行う
             List<Keys> hotkeyKeys = new List<Keys>(hotKeySettingForm.GetHotkeyKeys());
+            
+            //ホットキーが設定されていない場合は何もしない
+            if(hotkeyKeys.Count == 0)
+            {
+                return;
+            }
+
+            //ホットキーの設定をラベルに表示
             testlabel.Text = "ホットキー設定：" + string.Join(" + ", hotkeyKeys);
 
             int modKey = 0x0000;

--- a/HotKeySettingForm.cs
+++ b/HotKeySettingForm.cs
@@ -27,9 +27,18 @@ namespace ToggreMuter
 
         private void buttonSubmit_Click(object sender, EventArgs e)
         {
-            // OKボタンがクリックされたときにフォームを閉じる
-            DialogResult = DialogResult.OK;
-            Close();
+            // ホットキーが設定されていない場合はエラーを表示
+            if (HotkeyKeys.Count == 0)
+            {
+                MessageBox.Show("ホットキーが設定されていません。", "エラー", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+            else
+            {
+                // OKボタンがクリックされたときにフォームを閉じる
+                DialogResult = DialogResult.OK;
+                Close();
+            }
         }
 
         private void HotKeySettingForm_KeyDown(object sender, KeyEventArgs e)


### PR DESCRIPTION
https://github.com/niwanowa/ToggleMuter/issues/9